### PR TITLE
fix(fact-checker-cli): return default system prompt when prompt file is missing

### DIFF
--- a/docs/examples/fact-checker-cli/fact_checker.py
+++ b/docs/examples/fact-checker-cli/fact_checker.py
@@ -98,12 +98,14 @@ class FactChecker:
             print(f"Warning: Prompt file not found at {prompt_file}", file=sys.stderr)
         except Exception as e:
             print(f"Warning: Could not load system prompt from {prompt_file}: {e}", file=sys.stderr)
-            print("Using default system prompt.", file=sys.stderr)
-            return (
-                "You are a professional fact-checker with extensive research capabilities. "
-                "Your task is to evaluate claims or articles for factual accuracy. "
-                "Focus on identifying false, misleading, or unsubstantiated claims."
-            )
+
+        # Fallback default prompt if file loading fails
+        print("Using default system prompt.", file=sys.stderr)
+        return (
+            "You are a professional fact-checker with extensive research capabilities. "
+            "Your task is to evaluate claims or articles for factual accuracy. "
+            "Focus on identifying false, misleading, or unsubstantiated claims."
+        )
 
     def check_claim(self, text: str, model: str = DEFAULT_MODEL, use_structured_output: bool = False) -> Dict[str, Any]:
         """


### PR DESCRIPTION
## Description
`_load_system_prompt` in `docs/examples/fact-checker-cli/fact_checker.py` returns `None` when the prompt file is missing. The default prompt is only returned from inside the generic `except` branch, so the `FileNotFoundError` path prints a warning and falls through with no return value. The repo does not ship a `system_prompt.md` for this example (the directory contains only `README.mdx`, `fact_checker.py`, `requirements.txt`), so the documented Quick Start command hits this path on every run and silently sends `"system": null` to the API.

This moves the fallback out of the `except` block so the default prompt is returned unconditionally whenever loading fails. It matches the structure already used by `_load_system_prompt` in the sibling example `docs/examples/research-finder/research_finder.py`.

## Type of Contribution
- [ ] Example Tutorial
- [ ] Showcase Project
- [ ] Article/Integration Guide
- [ ] Documentation Update
- [x] Bug Fix
- [ ] Other (please describe)

## Checklist
- [ ] My code follows the cookbook's style guidelines
- [ ] I have included comprehensive documentation
- [x] I have tested my code and it works as expected
- [ ] I have included all necessary dependencies and setup instructions
- [ ] My MDX file includes proper frontmatter (title, description, keywords)
- [ ] I have linked to any external repositories or live demos

## Project Details
**What problem does this solve?**
Running the fact-checker example as documented sends `"system": null` to the API because the missing-file path never returns the default prompt.

**What makes this contribution valuable to other developers?**
The documented Quick Start command no longer sends a null system prompt to the API when no `system_prompt.md` is present.

## Testing
Verified locally: with no `system_prompt.md` present, the method returned `None` before and returns the non-empty default prompt string after.

## Additional Notes
One file changed: `docs/examples/fact-checker-cli/fact_checker.py`.
